### PR TITLE
fix(#36): align PlannerAgent constructor with coordinator + add async…

### DIFF
--- a/workers/agents/planner_agent.py
+++ b/workers/agents/planner_agent.py
@@ -4,6 +4,12 @@ Uses Gemma 4 via Ollama to produce a structured JSON plan.
 
 Fix (issue #6): timeout is now read from OLLAMA_TIMEOUT env var (default 300s)
 so that gemma4:27b cold-start on CPU-only hardware does not hit false timeouts.
+
+Fix (PR1 of audit-tracker #36): align constructor signature with
+AgentCoordinator._dispatch which instantiates every agent as
+`cls(config=..., guardrail=...)`, and add an `async run(payload)` method
+that returns `{"subtasks": [...]}` so the coordinator's DAG step can read
+`plan_task.result["subtasks"]` without a contract mismatch.
 """
 from __future__ import annotations
 
@@ -41,22 +47,35 @@ Goal: {goal}
 Context: {context}
 """
 
+
 class PlannerAgent:
+    """Planner agent. Constructor accepts (config, guardrail) like all other agents."""
+
     def __init__(
         self,
-        ollama_url: str = OLLAMA_URL,
-        model: str = MODEL,
-        timeout: float = OLLAMA_TIMEOUT,
+        config: Dict[str, Any] | None = None,
+        guardrail: Any | None = None,
     ) -> None:
-        self.ollama_url = ollama_url
-        self.model = model
-        self.timeout = timeout
+        self.config = config or {}
+        self.guardrail = guardrail  # planner does not gate actions, but kept for parity
+        self.ollama_url = self.config.get("ollama_url", OLLAMA_URL)
+        self.model = self.config.get("model", MODEL)
+        self.timeout = int(self.config.get("timeout", OLLAMA_TIMEOUT))
         logger.info(
             "PlannerAgent initialised: model=%s url=%s timeout=%s",
-            model,
-            ollama_url,
-            timeout,
+            self.model,
+            self.ollama_url,
+            self.timeout,
         )
+
+    async def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Coordinator entrypoint. Returns {"subtasks": [...]}."""
+        goal = payload.get("goal", "")
+        context = payload.get("context", "")
+        if isinstance(context, dict):
+            context = json.dumps(context)
+        subtasks = await self.plan(goal=goal, context=context)
+        return {"subtasks": subtasks}
 
     async def plan(self, goal: str, context: str = "") -> List[Dict[str, Any]]:
         """Call Ollama and return a list of subtask dicts.


### PR DESCRIPTION
… run()

PR1 of audit-tracker #36. AgentCoordinator._dispatch instantiates every agent as cls(config=..., guardrail=...), but PlannerAgent only accepted (ollama_url, model, timeout), causing TypeError on every run. Also, _dispatch awaits agent.run(payload) and the coordinator reads result['subtasks'], but PlannerAgent only had .plan() returning a list. This change: (a) makes the constructor accept (config, guardrail) like the other agents, (b) reads ollama_url/model/timeout from config with env defaults, (c) adds async run(payload) returning {'subtasks': [...]}. No behavior change beyond fixing the contract.