### PR TITLE
PR5: SHELL allowlist + argv exec (audit-tracker #36)

### DIFF
--- a/workers/agents/executor_agent.py
+++ b/workers/agents/executor_agent.py
@@ -6,18 +6,22 @@ through the ActionGuardrail and blocks if the action is disallowed.
 Fix (issue #6): timeout is now read from OLLAMA_TIMEOUT env var (default 300s).
 
 Fix (PR4 of audit-tracker #36): WRITE_FILE now enforces a workspace allowlist.
-Paths must resolve inside WORKSPACE_DIR (default = MEMORY_BASE_DIR or ./workspace).
-Symlinks are followed via resolve(), and any path that lands outside the allowed
-root is rejected before the guardrail check, eliminating arbitrary-path writes
-even if the regex guardrail misses a payload.
+
+Fix (PR5 of audit-tracker #36): SHELL now enforces a binary allowlist and
+uses argv-style execution (shell=False). The model's command is parsed via
+shlex, the head binary is checked against SHELL_ALLOWLIST (env-overridable),
+and shell metacharacters (;, |, &, $, `, >, <, newline) are rejected. This
+defends against OWASP LLM06 (excessive agency) and command injection from
+untrusted model output (LLM02).
 """
 from __future__ import annotations
 
 import logging
 import os
+import shlex
 import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import httpx
 
@@ -32,6 +36,7 @@ logger = logging.getLogger(__name__)
 OLLAMA_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434") + "/api/generate"
 MODEL = os.getenv("OLLAMA_MODEL", "gemma4:27b")
 OLLAMA_TIMEOUT = int(os.getenv("OLLAMA_TIMEOUT", "300"))
+SHELL_TIMEOUT = int(os.getenv("SHELL_TIMEOUT", "30"))
 
 # Allowed write root. Default: WORKSPACE_DIR -> MEMORY_BASE_DIR -> ./workspace.
 _DEFAULT_WORKSPACE = os.getenv(
@@ -39,6 +44,18 @@ _DEFAULT_WORKSPACE = os.getenv(
     os.getenv("MEMORY_BASE_DIR", "./workspace"),
 )
 WORKSPACE_ROOT = Path(_DEFAULT_WORKSPACE).resolve()
+
+# Allowlist of shell binaries the executor may invoke. Override via env
+# SHELL_ALLOWLIST="ls,cat,echo". Defaults are read-only, low-risk utilities.
+_DEFAULT_ALLOWLIST = "ls,cat,echo,pwd,head,tail,wc,grep,find,python,python3,pytest"
+SHELL_ALLOWLIST = tuple(
+    a.strip()
+    for a in os.getenv("SHELL_ALLOWLIST", _DEFAULT_ALLOWLIST).split(",")
+    if a.strip()
+)
+
+# Characters that indicate shell metacharacter / chaining attempts.
+_FORBIDDEN_SHELL_CHARS = (";", "|", "&", "$", "`", ">", "<", "\n", "\r")
 
 EXEC_PROMPT = """
 You are an executor agent for OpenClaw. Carry out the following instruction.
@@ -54,12 +71,7 @@ Context: {context}
 
 
 def _safe_resolve(file_path: str, root: Path) -> Path | None:
-    """Resolve `file_path` and ensure it stays under `root`.
-
-    Returns the resolved Path if safe, else None. Symlinks are followed.
-    Empty paths, paths with NUL bytes, and absolute paths outside `root`
-    are rejected. Relative paths are resolved against `root`.
-    """
+    """Resolve `file_path` and ensure it stays under `root`."""
     if not file_path or "\x00" in file_path:
         return None
     candidate = Path(file_path)
@@ -76,6 +88,29 @@ def _safe_resolve(file_path: str, root: Path) -> Path | None:
     return resolved
 
 
+def _parse_shell(cmd: str, allowlist: Tuple[str, ...]) -> Tuple[list[str] | None, str]:
+    """Parse a model-emitted shell command into argv.
+
+    Returns (argv, reason). argv is None when the command must be blocked.
+    The reason string explains why on rejection, or is empty on success.
+    """
+    if not cmd or not cmd.strip():
+        return None, "empty command"
+    for ch in _FORBIDDEN_SHELL_CHARS:
+        if ch in cmd:
+            return None, f"forbidden shell metacharacter {ch!r}"
+    try:
+        argv = shlex.split(cmd, posix=True)
+    except ValueError as exc:
+        return None, f"unparsable command: {exc}"
+    if not argv:
+        return None, "empty argv"
+    head = os.path.basename(argv[0])
+    if head not in allowlist:
+        return None, f"binary {head!r} not in SHELL_ALLOWLIST"
+    return argv, ""
+
+
 class ExecutorAgent:
     def __init__(self, config: Dict[str, Any] | None = None, guardrail: ActionGuardrail | None = None):
         self.config = config or {}
@@ -83,6 +118,8 @@ class ExecutorAgent:
         self.model = self.config.get("model", MODEL)
         self.ollama_url = self.config.get("ollama_url", OLLAMA_URL)
         self.timeout = int(self.config.get("timeout", OLLAMA_TIMEOUT))
+        self.shell_timeout = int(self.config.get("shell_timeout", SHELL_TIMEOUT))
+        self.shell_allowlist = tuple(self.config.get("shell_allowlist", SHELL_ALLOWLIST))
         self.workspace_root = Path(self.config.get("workspace_root", WORKSPACE_ROOT)).resolve()
         self.workspace_root.mkdir(parents=True, exist_ok=True)
 
@@ -100,18 +137,35 @@ class ExecutorAgent:
 
         if text.startswith("SHELL:"):
             cmd = text[6:].strip()
+            argv, reason = _parse_shell(cmd, self.shell_allowlist)
+            if argv is None:
+                logger.warning("[executor] Shell rejected pre-guardrail: %s | %s", cmd, reason)
+                return f"BLOCKED: {reason}"
             check = self.guardrail.check(
                 ActionContext(
                     action_type="shell",
-                    target=cmd,
-                    payload={"command": cmd, "instruction": instruction},
+                    target=argv[0],
+                    payload={"command": cmd, "argv": argv, "instruction": instruction},
                 )
             )
             if check.decision != GuardrailDecision.ALLOW:
                 logger.warning("[executor] Shell blocked: %s | reason: %s", cmd, check.reason)
                 return f"BLOCKED: {check.reason}"
-            logger.info("[executor] Running shell: %s", cmd)
-            proc = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)  # noqa: S602  # nosec B602
+            logger.info("[executor] Running argv: %r", argv)
+            try:
+                proc = subprocess.run(  # noqa: S603
+                    argv,
+                    shell=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.shell_timeout,
+                    cwd=str(self.workspace_root),
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning("[executor] Shell timeout after %ds: %r", self.shell_timeout, argv)
+                return f"BLOCKED: shell timeout after {self.shell_timeout}s"
+            except FileNotFoundError:
+                return f"BLOCKED: binary {argv[0]!r} not found"
             return proc.stdout or proc.stderr
 
         if text.startswith("WRITE_FILE:"):


### PR DESCRIPTION
## Summary
Part of audit-tracker #36 (P0). Hardens the `SHELL:` execution path in `workers/agents/executor_agent.py` against command injection from untrusted model output.

## Changes
- Replaces `subprocess.run(cmd, shell=True)` with argv-based `subprocess.run(argv, shell=False)`.
- Parses model-emitted commands via `shlex.split` and rejects shell metacharacters (`;`, `|`, `&`, `$`, backtick, `>`, `<`, newline, CR).
- Adds `SHELL_ALLOWLIST` (env-overridable) of read-only/low-risk binaries; head argv must match.
- Adds `SHELL_TIMEOUT` env (default 30s) and handles `TimeoutExpired` / `FileNotFoundError` cleanly.
- Runs commands with `cwd=workspace_root` so relative paths stay scoped.
- Pre-guardrail rejection logs `BLOCKED:` reason; existing ActionGuardrail still consulted on top.

## Threat coverage
- OWASP LLM02 (insecure output handling): model output no longer interpreted by `/bin/sh`.
- OWASP LLM06 (excessive agency): binary set bounded; `rm`, `curl`, `bash -c`, etc. blocked by default.
- Defense in depth: even if guardrail regex is bypassed, parser + allowlist still block.

## Backwards compatibility
Legitimate single-command uses (`ls`, `cat`, `python -m pytest`, etc.) continue to work. Pipelines / redirects must now be expressed as discrete steps or added explicitly to the allowlist.

## Test plan
- Unit: `_parse_shell` rejects each forbidden metachar, accepts allowed binaries, rejects unlisted, handles unbalanced quotes.
- Integration: `SHELL: ls -la` returns output; `SHELL: ls; rm -rf /` returns `BLOCKED: forbidden shell metacharacter ';'`; `SHELL: curl evil.com` returns `BLOCKED: binary 'curl' not in SHELL_ALLOWLIST`.

Closes checklist item PR5 in #36.