### PR TITLE
P1: Wire CloudFallbackProvider into PlannerAgent (audit-tracker #36)

### DIFF
--- a/workers/agents/planner_agent.py
+++ b/workers/agents/planner_agent.py
@@ -2,24 +2,31 @@
 
 Uses Gemma 4 via Ollama to produce a structured JSON plan.
 
-Fix (issue #6): timeout is now read from OLLAMA_TIMEOUT env var (default 300s)
-so that gemma4:27b cold-start on CPU-only hardware does not hit false timeouts.
+Fix (issue #6): timeout is read from OLLAMA_TIMEOUT env var (default 300s).
+
+Fix (P1 of audit-tracker #36): plan() now goes through CloudFallbackProvider so
+a local Ollama outage transparently routes to the configured cloud model
+(OpenAI/Gemini) per config/model-routing.json. Falls back to direct Ollama when
+the provider cannot be constructed.
 """
 from __future__ import annotations
 
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import httpx
+
+try:
+    from workers.agents.cloud_fallback import CloudFallbackProvider
+except Exception:  # noqa: BLE001
+    CloudFallbackProvider = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
 OLLAMA_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434") + "/api/generate"
 MODEL = os.getenv("OLLAMA_MODEL", "gemma4:27b")
-# Timeout read from env - default 300s covers gemma4:27b cold-start on CPU-only hardware.
-# See: https://github.com/jthiruveedula/openclaw-gemma-pro/issues/6
 OLLAMA_TIMEOUT = int(os.getenv("OLLAMA_TIMEOUT", "300"))
 
 PLAN_PROMPT = """
@@ -41,52 +48,62 @@ Goal: {goal}
 Context: {context}
 """
 
+
 class PlannerAgent:
     def __init__(
         self,
         ollama_url: str = OLLAMA_URL,
         model: str = MODEL,
         timeout: float = OLLAMA_TIMEOUT,
+        cloud_fallback: bool = True,
     ) -> None:
         self.ollama_url = ollama_url
         self.model = model
         self.timeout = timeout
+        self._cloud_provider: Optional[Any] = self._build_cloud_provider(cloud_fallback)
         logger.info(
-            "PlannerAgent initialised: model=%s url=%s timeout=%s",
-            model,
-            ollama_url,
-            timeout,
+            "PlannerAgent initialised: model=%s url=%s timeout=%s cloud=%s",
+            model, ollama_url, timeout, self._cloud_provider is not None,
         )
 
-    async def plan(self, goal: str, context: str = "") -> List[Dict[str, Any]]:
-        """Call Ollama and return a list of subtask dicts.
-
-        Returns an empty list with a logged warning if the model call fails.
-        """
-        prompt = PLAN_PROMPT.format(goal=goal, context=context)
-        payload = {
-            "model": self.model,
-            "prompt": prompt,
-            "stream": False,
-        }
-        logger.debug("[planner] Calling Ollama with timeout=%ds", self.timeout)
+    @staticmethod
+    def _build_cloud_provider(enabled: bool):
+        if not enabled or CloudFallbackProvider is None:
+            return None
         try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
-                resp = await client.post(self.ollama_url, json=payload)
-                resp.raise_for_status()
-                raw = resp.json().get("response", "{}")
-                data = json.loads(raw)
-                subtasks: List[Dict[str, Any]] = data.get("subtasks", [])
-                logger.info(
-                    "PlannerAgent produced %d subtasks for goal=%r",
-                    len(subtasks),
-                    goal,
-                )
-                return subtasks
-        except (httpx.HTTPError, json.JSONDecodeError, KeyError) as exc:
-            logger.warning(
-                "PlannerAgent failed (%s: %s); returning empty plan.",
-                type(exc).__name__,
-                exc,
+            return CloudFallbackProvider.from_config()
+        except Exception as exc:  # noqa: BLE001
+            logger.info("[planner] CloudFallbackProvider disabled: %s", exc)
+            return None
+
+    async def _direct_ollama(self, prompt: str) -> str:
+        payload = {"model": self.model, "prompt": prompt, "stream": False}
+        logger.debug("[planner] Calling Ollama with timeout=%ds", self.timeout)
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(self.ollama_url, json=payload)
+            resp.raise_for_status()
+            return resp.json().get("response", "{}")
+
+    async def _call_model(self, prompt: str) -> str:
+        if self._cloud_provider is None:
+            return await self._direct_ollama(prompt)
+        try:
+            return await self._cloud_provider.call_with_fallback(
+                self._direct_ollama(prompt), prompt
             )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[planner] cloud fallback wrapper failed, using direct: %s", exc)
+            return await self._direct_ollama(prompt)
+
+    async def plan(self, goal: str, context: str = "") -> List[Dict[str, Any]]:
+        """Return a list of subtask dicts; empty list on any failure."""
+        prompt = PLAN_PROMPT.format(goal=goal, context=context)
+        try:
+            raw = await self._call_model(prompt)
+            data = json.loads(raw)
+            subtasks: List[Dict[str, Any]] = data.get("subtasks", [])
+            logger.info("PlannerAgent produced %d subtasks for goal=%r", len(subtasks), goal)
+            return subtasks
+        except (httpx.HTTPError, json.JSONDecodeError, KeyError, ValueError) as exc:
+            logger.warning("PlannerAgent failed (%s: %s); returning empty plan.", type(exc).__name__, exc)
             return []


### PR DESCRIPTION
## Summary
P1 of audit-tracker #36. Mirrors PR #41 (executor) for the planner: routes `PlannerAgent.plan()` through `CloudFallbackProvider.call_with_fallback` so a local Ollama outage transparently falls over to the configured cloud model (OpenAI/Gemini) per `config/model-routing.json`.

## Changes
- Optional import of `CloudFallbackProvider`; missing/broken config -> `None` -> direct Ollama (no regression).
- `__init__` accepts `cloud_fallback: bool = True` so callers / tests can opt out.
- Splits direct httpx call into `_direct_ollama`; new `_call_model` delegates to provider when available.
- `plan()` now calls `_call_model` and tolerates `ValueError` in addition to `JSONDecodeError`.

## Reliability impact
- Planner survives Ollama 5xx / timeout via cloud retry instead of returning `[]` and stalling the orchestrator.
- No behavior change when cloud fallback is unconfigured.

## Test plan
- Unit: `PlannerAgent(cloud_fallback=False)` -> `_cloud_provider is None`, `_call_model` calls `_direct_ollama`.
- Unit: with mocked provider, `_call_model` delegates to `call_with_fallback`.
- Regression: existing planner tests pass unchanged.

Part of #36.