### PR TITLE
P1-D: Add gitleaks CI workflow for secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+name: gitleaks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for leaked secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+


### PR DESCRIPTION
## Summary
Adds `.github/workflows/gitleaks.yml` to scan the repository for hardcoded secrets and credentials on every push to `main`, every pull request, and a weekly Monday cron sweep.

Part of audit-tracker #36 (P1-D).

## Motivation
The audit (issue #36) flagged the absence of automated secret scanning as a gap. With multiple agent components reading API keys from env, accidental commits of `.env` values or test fixtures containing real keys are a realistic risk. Gitleaks provides defense-in-depth alongside `.gitignore` and `.env.example`.

## Workflow design
- Triggers: `push` to main, all `pull_request` events, weekly cron (Monday 06:00 UTC)
- `permissions: contents: read` (least privilege)
- `fetch-depth: 0` so gitleaks can scan full history on PRs
- 10-minute job timeout
- `GITLEAKS_ENABLE_COMMENTS: false` (avoids noisy PR comments; results visible in checks tab)
- `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true` (SARIF/json artifact retained for triage)

## Threat model addressed (OWASP LLM 2025)
- LLM06 Sensitive Information Disclosure — catches accidental commits of API keys, OAuth tokens, private keys before they reach `main`.

## Test plan
- Merge → verify the workflow appears under Actions and runs green on a clean repo.
- Optional: open a throwaway PR with a fake AWS-style key to confirm detection, then close.

## Risk / rollback
CI-only addition. No production code or runtime behavior changed. Disable by deleting the workflow file or setting `if: false` on the job.

## Residual risks
- Pinned to `gitleaks-action@v2` (major). Consider pinning to a SHA in a follow-up for supply-chain hardening.
- No custom `.gitleaks.toml` yet — follow-up to tune false-positives if any surface.
